### PR TITLE
Support client-side Blazor with .NET Standard 2.1

### DIFF
--- a/Blazor.PWA.MSBuild.Tasks/build/BlazorPWA.MSBuild.targets
+++ b/Blazor.PWA.MSBuild.Tasks/build/BlazorPWA.MSBuild.targets
@@ -9,6 +9,7 @@
     <BlazorProjectType Condition="'$(BlazorProjectType)' == '' AND '$(TargetFramework)' == 'netcoreapp3.1'">SSB</BlazorProjectType>
     <BlazorProjectType Condition="'$(BlazorProjectType)' == '' AND '$(TargetFramework)' == 'netcoreapp3.0'">SSB</BlazorProjectType>
     <BlazorProjectType Condition="'$(BlazorProjectType)' == '' AND '$(TargetFramework)' == 'netstandard2.0'">CSB</BlazorProjectType>
+    <BlazorProjectType Condition="'$(BlazorProjectType)' == '' AND '$(TargetFramework)' == 'netstandard2.1'">CSB</BlazorProjectType>
   </PropertyGroup>
 
   <PropertyGroup Label="ServiceWorker">


### PR DESCRIPTION
As of .NET Core 3.1, client-side Blazor supports .NET Standard 2.1. We need to recognize this as CSB.